### PR TITLE
fix column & offset width calculations when using other than 12 columns

### DIFF
--- a/scss/mixins/_grid-framework.scss
+++ b/scss/mixins/_grid-framework.scss
@@ -10,7 +10,7 @@
 @mixin make-offset($columns) {
   @for $number from 1 through $columns {
     &-offset-#{$number} {
-      margin-left: (100 / 12 * $number)#{'%'};
+      margin-left: (100 / $columns * $number)#{'%'};
     }
   }
 }
@@ -18,7 +18,7 @@
 @mixin make-column($columns ) {
   @for $number from 1 through $columns {
     &-#{$number} {
-      width: (100 / 12 * $number)#{'%'};
+      width: (100 / $columns * $number)#{'%'};
       flex: none;
     }
   }


### PR DESCRIPTION
The number 12 is hard-coded in the calculations in `make-offset` and `make-column`, which means that the math is incorrect when changing the number of columns.

This patch replaces the hard-coded values with the total number of columns in the grid, so the calculations are correct.
